### PR TITLE
🔒 💚 Add snyk and remove redundant organize-imports scalafix plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fs2-aes
 [![License](http://img.shields.io/:license-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Maven Central](https://img.shields.io/maven-central/v/me.wojnowski/fs2-aes_3.svg?color=blue)](https://search.maven.org/search?q=fs2-aes)
+[![Known Vulnerabilities](https://snyk.io/test/github/jwojnowski/fs2-aes/badge.svg)](https://snyk.io/test/github/jwojnowski/fs2-aes)
 
 This is a micro library providing AES encryption/decryption of `fs2.Stream[F, Byte]`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,4 @@ lazy val root = (project in file("."))
     )
   )
 
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
-
 ThisBuild / mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet


### PR DESCRIPTION
The organize-imports plugin is now a build-in part of scalafix and it causes Snyk false-positives.