### PR TITLE
Revert "Update scalafmt-core to 3.7.16"

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.16"
+version = "3.7.15"
 runner.dialect = scala213
 maxColumn = 140
 align.preset = most


### PR DESCRIPTION
Reverts jwojnowski/fs2-aes#43 because of [failing CI](https://github.com/jwojnowski/fs2-aes/actions/runs/6839800562) (scalafmt issue: https://github.com/scalameta/scalafmt/issues/3689).